### PR TITLE
ADD MsgId for webot send

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -31,7 +31,7 @@ exports.makeRequest = function(url, token){
   return function(info, cb){
     //默认值
     info = _.isString(info) ? {text: info} : info;
-    
+
     _.defaults(info, {
       sp: 'webot',
       user: 'client',
@@ -45,7 +45,7 @@ exports.makeRequest = function(url, token){
     });
 
     var content = exports.info2xml(info);
-    
+
     //发送请求
     request.post({
       url: url,
@@ -81,6 +81,7 @@ exports.makeRequest = function(url, token){
  */
 exports.info2xml = _.template([
   '<xml>',
+    '<MsgId>1234567</MsgId>',
     '<ToUserName><![CDATA[<%= sp %>]]></ToUserName>',
     '<FromUserName><![CDATA[<%= user %>]]></FromUserName>',
     '<CreateTime><%= Math.round(new Date().getTime() / 1000) %></CreateTime>',


### PR DESCRIPTION
使用 webot send text 命令测试微信应用时，有些微信API库要求必须有MsgId。
