### PR TITLE
修改控制台的输出样式为json，保持同菜单输入时候传入格式一致

### DIFF
--- a/lib/commands/menu.js
+++ b/lib/commands/menu.js
@@ -35,6 +35,7 @@ function cleanReturns(callback) {
     if (json.errcode) {
       console.error('[ERROR %s]'.red, json.errcode, json.errmsg);
     } else {
+      // 修改控制台的输出样式为json，保持同菜单输入时候传入格式一致
       console.log(JSON.stringify(json, null, 2));
       // console.log(prettyjson.render(json));
     }

--- a/lib/commands/menu.js
+++ b/lib/commands/menu.js
@@ -35,7 +35,8 @@ function cleanReturns(callback) {
     if (json.errcode) {
       console.error('[ERROR %s]'.red, json.errcode, json.errmsg);
     } else {
-      console.log(prettyjson.render(json));
+      console.log(JSON.stringify(json, null, 2));
+      // console.log(prettyjson.render(json));
     }
     console.error();
 


### PR DESCRIPTION
有时候push微信菜单的时候怕配置错误应该先拉一次最新的，但是默认大神写的格式和使用menu create .. < menu_config.json的格式不一致，就算拉出来了，为了用create命令push上去还得手动改下，所以修改了控制台输出数据的样式为json方便一点。
